### PR TITLE
Use Object.prototype.hasOwnProperty; not on object

### DIFF
--- a/lib/areSameQuery.js
+++ b/lib/areSameQuery.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 
 // TODO :: add a skipEmpties ?
@@ -10,9 +11,8 @@ function areSameQuery(queryObj1, queryObj2)
 	
 	for (i in queryObj1)
 	{
-		value1 = queryObj1.hasOwnProperty(i);
-		value2 = queryObj2.hasOwnProperty(i);
-		
+		value1 = hasOwnProperty.call(queryObj1, i);
+		value2 = hasOwnProperty.call(queryObj2, i);
 		if (value1===false || value2===false || value1!==value2) return false;
 		
 		value1 = queryObj1[i];


### PR DESCRIPTION
As of Node 6, `querystring.parse()` returns an object with no prototype,
which means that it doesn't have its own `hasOwnProperty()`

https://github.com/nodejs/node/wiki/Breaking-changes-between-v5-and-v6#querystring